### PR TITLE
Update to supported nightly

### DIFF
--- a/templates/Dockerfile.base
+++ b/templates/Dockerfile.base
@@ -11,7 +11,7 @@ RUN apt-get update && \
 
 # Install rust as required by substrate env
 # Pick up the version from https://rust-lang.github.io/rustup-components-history/index.html (rls is required)
-ARG RUST_VERSION=nightly-2020-10-06
+ARG RUST_VERSION=nightly-2020-10-05
 ARG USER=playground
 ARG HOME=/home/$USER
 ARG WORKSPACE=$HOME/workspace


### PR DESCRIPTION
Fix broken build caused by https://github.com/substrate-developer-hub/substrate-node-template/pull/98